### PR TITLE
Multi-paragraph quotes with more than one <strong> doesn't work

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = {
 							function ()
 							{
 								$this = $( this );
-								$strong = $this.find( "p > strong:first-child" );
+								$strong = $this.find( "p:first-child > strong:first-child" );
 								if( $strong )
 								{
 									switch ( $strong.text().toLowerCase() )


### PR DESCRIPTION
Consider the following Markdown quote:

```
> **Note** First paragraph with a **bold**.
> 
> Second paragraph with a **bold**.
```

It renders a `blockquote` with two `p` with `strong` inside them.

The result is:
![richquotes_not_working](https://cloud.githubusercontent.com/assets/258331/4512651/cd2e2ade-4b42-11e4-9411-9ac6a95a4c91.png)

The problem is that when we do `$this.find( "p > strong:first-child" )` it will get both `p`. Then, when we do `$strong.text()`, we'll the contents of both concatenated.

So, I changed the selection to `$this.find( "p:first-child > strong:first-child" )`, in order to get only the first `strong` of the first `p` in the `blockquote`.

The result is the following:
![richquotes_working](https://cloud.githubusercontent.com/assets/258331/4512708/84d637b2-4b43-11e4-9971-d829762c77f2.png)
